### PR TITLE
Ask tools not to integrate ocs-manager's AppImage

### DIFF
--- a/desktop/ocs-manager.desktop
+++ b/desktop/ocs-manager.desktop
@@ -6,3 +6,4 @@ Type=Application
 Terminal=true
 NoDisplay=true
 Categories=Network;Utility;
+X-AppImage-Integrate=false


### PR DESCRIPTION
Proper fix for https://github.com/TheAssassin/AppImageLauncher/issues/11. See https://github.com/TheAssassin/AppImageLauncher/issues/12 for more information.